### PR TITLE
Support for Istio telemetry v2

### DIFF
--- a/config/grafana/istio-telemetry-v2.json
+++ b/config/grafana/istio-telemetry-v2.json
@@ -1,0 +1,1333 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Metrics Relevant to Iter8 Experiments",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1561057163257,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "panels": [],
+      "repeat": null,
+      "title": "Application Metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Request rate",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Requests per sec",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Mean latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "mean latency (ms)",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline-25%",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate-25%",
+          "refId": "E"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline-50%",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate-50%",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline-75%",
+          "refId": "D"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate-75%",
+          "refId": "F"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline-95%",
+          "refId": "G"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate-95%",
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Latency percentiles",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source', response_code =~ \"5..\"}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source', response_code =~ \"5..\"}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Fraction of requests with status 5**",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source', response_code =~ \"5..\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$baseline",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source', response_code =~ \"5..\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "$candidate",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Error counts",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Number of requests with status 5**",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 16,
+      "panels": [],
+      "repeat": null,
+      "title": "Utilization Metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "hideTimeOverride": false,
+      "id": 18,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": true,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU Utilization ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "CPU changes per second",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage of Working Set ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Bytes Used per second",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Container selector does not apply here",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Bytes Received ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Bytes Received Per Second",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Bytes Sent ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Bytes Transmitted Per Second",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Bytes Read ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Bytes Read Per Second",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$baseline}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{$candidate}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Bytes Written ($window_size)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Bytes Per Second Written",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [
+    "iter8"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "reviews",
+          "value": "reviews"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(istio_requests_total{destination_service_namespace='$namespace', destination_service_name != 'unknown'}, destination_service_name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Service",
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": "label_values(istio_requests_total{destination_service_namespace='$namespace', destination_service_name != 'unknown'}, destination_service_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": false,
+        "datasource": "Prometheus",
+        "definition": "label_values(istio_requests_total{destination_service_name = '$service', destination_service_namespace='$namespace', destination_workload != 'unknown'}, destination_workload)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Baseline",
+        "multi": false,
+        "name": "baseline",
+        "options": [],
+        "query": "label_values(istio_requests_total{destination_service_name = '$service', destination_service_namespace='$namespace', destination_workload != 'unknown'}, destination_workload)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": false,
+        "datasource": "Prometheus",
+        "definition": "label_values(istio_requests_total{destination_service_name = '$service', destination_service_namespace = '$namespace', destination_workload != 'unknown'}, destination_workload)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Candidate",
+        "multi": false,
+        "name": "candidate",
+        "options": [],
+        "query": "label_values(istio_requests_total{destination_service_name = '$service', destination_service_namespace = '$namespace', destination_workload != 'unknown'}, destination_workload)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(istio_requests_total{destination_service_namespace!='unknown'}, destination_service_namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [
+          {
+            "selected": true,
+            "text": "default",
+            "value": "default"
+          }
+        ],
+        "query": "label_values(istio_requests_total{destination_service_namespace!='unknown'}, destination_service_namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "30s",
+        "current": {
+          "text": "30s",
+          "value": "30s"
+        },
+        "hide": 0,
+        "label": "Window Size",
+        "name": "window_size",
+        "options": [
+          {
+            "selected": false,
+            "text": "auto",
+            "value": "$__auto_interval_window_size"
+          },
+          {
+            "selected": true,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "30s, 1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Iter8 Metrics",
+  "uid": "eXPEaNnZz"
+}

--- a/doc/tutorials/istio/bookinfo/canary_productpage-v1_to_productpage-v2_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_productpage-v1_to_productpage-v2_telemetry-v2.yaml
@@ -1,0 +1,27 @@
+apiVersion: iter8.tools/v1alpha1
+kind: Experiment
+metadata:
+  name: productpage-v2-rollout
+spec:
+  routingReference:
+    apiVersion: networking.istio.io/v1alpha3
+    kind: VirtualService
+    name: bookinfo
+  targetService:
+    name: productpage
+    apiVersion: v1
+    baseline: productpage-v1
+    candidate: productpage-v2
+  trafficControl:
+    strategy: check_and_increment
+    interval: 30s
+    trafficStepSize: 20
+    maxIterations: 6
+    maxTrafficPercentage: 80
+  analysis:
+    analyticsService: "http://iter8-analytics.iter8"
+    successCriteria:
+      - metricName: iter8_latency
+        toleranceType: threshold
+        tolerance: 3000
+        sampleSize: 5

--- a/doc/tutorials/istio/bookinfo/canary_reviews-v2_to_reviews-v3_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_reviews-v2_to_reviews-v3_telemetry-v2.yaml
@@ -1,0 +1,23 @@
+apiVersion: iter8.tools/v1alpha1
+kind: Experiment
+metadata:
+  name: reviews-v3-rollout
+spec:
+  targetService:
+    name: reviews
+    apiVersion: v1
+    baseline: reviews-v2
+    candidate: reviews-v3
+  trafficControl:
+    strategy: check_and_increment
+    interval: 30s
+    trafficStepSize: 20
+    maxIterations: 8
+    maxTrafficPercentage: 80
+  analysis:
+    analyticsService: "http://iter8-analytics.iter8"
+    successCriteria:
+      - metricName: iter8_latency
+        toleranceType: threshold
+        tolerance: 200
+        sampleSize: 5

--- a/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v4_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v4_telemetry-v2.yaml
@@ -1,0 +1,23 @@
+apiVersion: iter8.tools/v1alpha1
+kind: Experiment
+metadata:
+  name: reviews-v4-rollout
+spec:
+  targetService:
+    name: reviews
+    apiVersion: v1
+    baseline: reviews-v3
+    candidate: reviews-v4
+  trafficControl:
+    strategy: check_and_increment
+    interval: 30s
+    trafficStepSize: 20
+    maxIterations: 6
+    maxTrafficPercentage: 80
+  analysis:
+    analyticsService: "http://iter8-analytics.iter8"
+    successCriteria:
+      - metricName: iter8_latency
+        toleranceType: threshold
+        tolerance: 200
+        sampleSize: 5

--- a/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v5_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v5_telemetry-v2.yaml
@@ -1,0 +1,28 @@
+apiVersion: iter8.tools/v1alpha1
+kind: Experiment
+metadata:
+  name: reviews-v5-rollout
+spec:
+  targetService:
+    name: reviews
+    apiVersion: v1
+    baseline: reviews-v3
+    candidate: reviews-v5
+  trafficControl:
+    strategy: check_and_increment
+    interval: 30s
+    trafficStepSize: 20
+    maxIterations: 6
+    maxTrafficPercentage: 80
+  analysis:
+    analyticsService: "http://iter8-analytics.iter8"
+    successCriteria:
+      - metricName: iter8_latency
+        toleranceType: threshold
+        tolerance: 200
+        sampleSize: 5
+      - metricName: iter8_error_rate
+        toleranceType: delta
+        tolerance: 0.02
+        sampleSize: 10
+        stopOnFailure: true

--- a/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v6_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_reviews-v3_to_reviews-v6_telemetry-v2.yaml
@@ -1,0 +1,23 @@
+apiVersion: iter8.tools/v1alpha1
+kind: Experiment
+metadata:
+  name: reviews-v6-rollout
+spec:
+  targetService:
+    name: reviews
+    apiVersion: v1
+    baseline: reviews-v3
+    candidate: reviews-v6
+  trafficControl:
+    strategy: check_and_increment
+    interval: 30s
+    trafficStepSize: 20
+    maxIterations: 6
+    maxTrafficPercentage: 80
+  analysis:
+    analyticsService: "http://iter8-analytics.iter8"
+    successCriteria:
+      - metricName: iter8_90_perc_latency
+        toleranceType: threshold
+        tolerance: 200
+        sampleSize: 5

--- a/doc/tutorials/istio/bookinfo/iter8_metrics_extended_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/iter8_metrics_extended_telemetry-v2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iter8config-metrics
+  namespace: iter8
+data:
+  query_templates: |-
+    iter8_sample_size: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
+    iter8_latency: "(sum(increase(istio_request_duration_milliseconds_sum{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)) / (sum(increase(istio_request_duration_milliseconds_count{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels))"
+    iter8_error_count: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',response_code=~'5..',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
+    iter8_error_rate: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',response_code=~'5..',reporter='source'}[$interval]$offset_str)) by ($entity_labels) / sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
+    iter8_90_perc_latency: "histogram_quantile(0.90, sum(increase(istio_request_duration_milliseconds_bucket{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels, le))"
+  metrics: |-
+    - name: iter8_latency
+      is_counter: False
+      absent_value: "None"
+      sample_size_query_template: iter8_sample_size
+    - name: iter8_error_count
+      is_counter: True
+      sample_size_query_template: iter8_sample_size
+    - name: iter8_error_rate
+      is_counter: False
+      sample_size_query_template: iter8_sample_size
+    - name: iter8_90_perc_latency
+      is_counter: False
+      absent_value: "None"
+      sample_size_query_template: iter8_sample_size

--- a/install/helm/iter8-controller/templates/metrics/iter8_metrics.yaml
+++ b/install/helm/iter8-controller/templates/metrics/iter8_metrics.yaml
@@ -6,7 +6,11 @@ metadata:
 data:
   query_templates: |-
     iter8_sample_size: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
+    {{- if eq .Values.istioTelemetry "v1" }}
     iter8_latency: "(sum(increase(istio_request_duration_seconds_sum{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)) / (sum(increase(istio_request_duration_seconds_count{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels))"
+    {{- else }}
+    iter8_latency: "(sum(increase(istio_request_duration_milliseconds_sum{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)) / (sum(increase(istio_request_duration_milliseconds_count{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels))"
+    {{- end }}
     iter8_error_count: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',response_code=~'5..',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
     iter8_error_rate: "sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',response_code=~'5..',reporter='source'}[$interval]$offset_str)) by ($entity_labels) / sum(increase(istio_requests_total{source_workload_namespace!='knative-serving',reporter='source'}[$interval]$offset_str)) by ($entity_labels)"
   metrics: |-

--- a/install/helm/iter8-controller/values.yaml
+++ b/install/helm/iter8-controller/values.yaml
@@ -8,3 +8,6 @@ image:
   pullPolicy: Always
 
 namespace: iter8
+
+# Version of Istio telemetry
+istioTelemetry: v1


### PR DESCRIPTION
1. Created a new Grafana dashboard compatible with Istio telemetry-v2.
2. Changed the Helm chart to take the Istio telemetry version as a parameter so that query templates are created accordingly.
3. Created tutorial files compatible with Istio telemety-v2: latency is expressed in milliseconds.