### PR TITLE
Added Grafana dashboards for all 4 combinations of affected versions …

### DIFF
--- a/config/grafana/istio-telemetry-v1-k8s-16.json
+++ b/config/grafana/istio-telemetry-v1-k8s-16.json
@@ -162,14 +162,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "expr": "sum(increase(istio_request_duration_seconds_sum{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "expr": "sum(increase(istio_request_duration_seconds_sum{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate",
@@ -197,7 +197,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "mean latency (ms)",
+          "label": "mean latency (sec)",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -253,56 +253,56 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-25%",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-25%",
           "refId": "E"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-50%",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-50%",
           "refId": "C"
         },
         {
-          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-75%",
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-75%",
           "refId": "F"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-95%",
           "refId": "G"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-95%",
@@ -589,7 +589,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -598,7 +598,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -683,7 +683,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_memory_working_set_bytes{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -691,7 +691,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_memory_working_set_bytes{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -780,14 +780,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod_name=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod_name=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -871,14 +871,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod_name=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod_name=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -962,14 +962,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -1053,14 +1053,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",

--- a/config/grafana/istio-telemetry-v1.json
+++ b/config/grafana/istio-telemetry-v1.json
@@ -162,14 +162,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "expr": "sum(increase(istio_request_duration_seconds_sum{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(istio_request_duration_milliseconds_sum{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
+          "expr": "sum(increase(istio_request_duration_seconds_sum{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) / sum(increase(istio_requests_total{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter = 'source'}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate",
@@ -197,7 +197,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "mean latency (ms)",
+          "label": "mean latency (sec)",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -253,56 +253,56 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-25%",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.25, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-25%",
           "refId": "E"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-50%",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-50%",
           "refId": "C"
         },
         {
-          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-75%",
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.75, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-75%",
           "refId": "F"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[baseline]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$baseline-95%",
           "refId": "G"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_seconds_bucket{destination_workload=~'[[candidate]]', destination_service_namespace='$namespace', reporter='source'}[$window_size])) by (le))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "$candidate-95%",

--- a/config/grafana/istio-telemetry-v2-k8s-16.json
+++ b/config/grafana/istio-telemetry-v2-k8s-16.json
@@ -589,7 +589,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -598,7 +598,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -683,7 +683,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_memory_working_set_bytes{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -691,7 +691,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_memory_working_set_bytes{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_memory_working_set_bytes{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -780,14 +780,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod_name=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod_name=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -871,14 +871,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod_name=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$baseline.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod_name=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$candidate.*\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -962,14 +962,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",
@@ -1053,14 +1053,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{pod_name=~\"$baseline.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$baseline.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$baseline}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{pod_name=~\"$candidate.*\", container_name!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{pod=~\"$candidate.*\", container!~\"istio-proxy\", namespace=\"$namespace\"}[$window_size]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$candidate}}",


### PR DESCRIPTION
…of Istio telemetry and K8s.

Note that this PR is for merging with the v0.1 branch for targeting our next 0.1.0 release.

This PR creates 4 Grafana dashboard files targeting different versions of Istio telemetry and K8s as follows:
- istio-telemetry-v1.json: Istio telemetry v1 and K8s before 1.16
- istio-telemetry-v1-k8s-16.json: Istio telemetry v1 and K8s 1.6 and later.
- istio-telemetry-v2.json: Istio telemetry v2 and K8s before 1.16
- istio-telemetry-v2-k8s-16.json: Istio telemetry v2 and K8s 1.6 and later.