### PR TITLE
sets absent_value for error_count and error_rate metrics

### DIFF
--- a/install/helm/iter8-controller/templates/metrics/iter8_metrics.yaml
+++ b/install/helm/iter8-controller/templates/metrics/iter8_metrics.yaml
@@ -20,7 +20,9 @@ data:
       sample_size_query_template: iter8_sample_size
     - name: iter8_error_count
       is_counter: True
+      absent_value: 0
       sample_size_query_template: iter8_sample_size
     - name: iter8_error_rate
       is_counter: False
+      absent_value: 0
       sample_size_query_template: iter8_sample_size


### PR DESCRIPTION
Fixes the problem that 2/3 default metrics are broken out of box. 