### PR TITLE
filter out .DS_Store files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bin
 
 # Go package lock file
 *Gopkg.lock*
+
+# Mac file information
+**/.DS_Store


### PR DESCRIPTION
I don't know why I see these files but they are annoying. It stands for _Desktop Services Store_ and it holds meta information about your folder's thumbnails, settings, etc. . DS_Store files are created any time you navigate to a file or folder from the Finder on a Mac.

A stackoverflow comments suggests this might be caused by an accidental commit of these files in the past.