### PR TITLE
fix status update

### DIFF
--- a/pkg/apis/iter8/v1alpha1/experiment_types.go
+++ b/pkg/apis/iter8/v1alpha1/experiment_types.go
@@ -502,8 +502,8 @@ const (
 	ReasonSyncMetricsSucceeded    = "SyncMetricsSucceeded"
 	ReasonRoutingRulesError       = "RoutingRulesError"
 	ReasonRoutingRulesReady       = "RoutingRulesReady"
-	ReasonActionPause             = "ActionPause"
-	ReasonActionResume            = "ActionResume"
+	ReasonActionPause             = "Pause"
+	ReasonActionResume            = "Resume"
 )
 
 // Init initialize status values

--- a/pkg/controller/experiment/experiment_controller.go
+++ b/pkg/controller/experiment/experiment_controller.go
@@ -330,7 +330,7 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if err := r.syncMetrics(ctx, instance); err != nil {
-		return reconcile.Result{}, nil
+		return r.endRequest(ctx, instance)
 	}
 
 	switch instance.Spec.TargetService.APIVersion {
@@ -352,13 +352,6 @@ func (r *ReconcileExperiment) syncMetrics(ctx context.Context, instance *iter8v1
 	if metricsSycned == nil || metricsSycned.Status != corev1.ConditionTrue {
 		if err := metrics.Read(ctx, r, instance); err != nil && !validUpdateErr(err) {
 			r.MarkSyncMetricsError(ctx, instance, "Fail to read metrics: %v", err)
-
-			if err := r.Status().Update(ctx, instance); err != nil && !validUpdateErr(err) {
-				log.Info("Fail to update status: %v", err)
-				// TODO: need a better way of handling this error
-				return err
-			}
-
 			return err
 		}
 		r.MarkSyncMetrics(ctx, instance)


### PR DESCRIPTION
As bug pointed out by @jadeyliu939, when resume is performed before next iteration, status of experiment may not be properly updated.

This pr enforces the controller to check status changes every time request ends, and performs update if required.