### PR TITLE
simplify image tag

### DIFF
--- a/test/e2e/build-image.sh
+++ b/test/e2e/build-image.sh
@@ -2,18 +2,18 @@
 
 # Only build images for master and v[0-9]+.[0-9]+ release branches
 if [[ "$TRAVIS_BRANCH" == "master" ]] || [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+$ ]] ; then
-  echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin;
   # Only build images when commits are done on these branches
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    export IMG="iter8/iter8-controller:$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT";
-    echo "Building Docker image - $IMG";
+    echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin;
+    export IMG="iter8/iter8-controller:$TRAVIS_BRANCH";
+    echo "Building PR Docker image - $IMG";
     make docker-build;
     make docker-push;
-    LATEST="iter8/iter8-controller:latest";
-    echo "Tagging image as latest - $LATEST";
-    docker tag $IMG $LATEST;
-    export IMG=$LATEST;
-    make docker-push;
+    #LATEST="iter8/iter8-controller:latest";
+    #echo "Tagging image as latest - $LATEST";
+    #docker tag $IMG $LATEST;
+    #export IMG=$LATEST;
+    #make docker-push;
   fi
 fi
 


### PR DESCRIPTION
1. On PR merge, change image name to `:$TRAVIS_BRANCH`
2. On PR merge on `master` branch, do NOT tag image as `latest`. (Another PR will tag the latest release branch as `latest` image.