### PR TITLE
optimize travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ stages:
 
 # Define yaml anchor to be reused across testing matrix
 _end_to_end_script: &end_to_end_script
+  if: (type = pull_request) AND (head_branch != master) AND (head_branch !~ /^v[0-9]+\.[0-9]+$/)
   script:
     - test/e2e/install-minikube.sh
     - test/e2e/sanity-check.sh
@@ -22,6 +23,7 @@ jobs:
       go_import_path: github.com/iter8-tools/iter8-controller/
       before_install:
         - ./test/scripts/tools.sh
+      if: (type = pull_request) AND (head_branch != master) AND (head_branch !~ /^v[0-9]+\.[0-9]+$/)
       script:
         - go test ./test/.
     - stage: "end-to-end tests"
@@ -34,5 +36,6 @@ jobs:
     - env: KUBE_VERSION=v1.16.0 ISTIO_VERSION=1.4.6
       <<: *end_to_end_script
     - stage: "build image"
+      if: (type = push) AND (branch = master OR branch =~ /^v[0-9]+\.[0-9]+$/)
       script:
         - test/e2e/build-image.sh

--- a/test/e2e/build-image.sh
+++ b/test/e2e/build-image.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 
-# Only build images for master and v[0-9]+.[0-9]+ release branches
-if [[ "$TRAVIS_BRANCH" == "master" ]] || [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+$ ]] ; then
-  # Only build images when commits are done on these branches
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin;
-    export IMG="iter8/iter8-controller:$TRAVIS_BRANCH";
-    echo "Building PR Docker image - $IMG";
-    make docker-build;
-    make docker-push;
-    #LATEST="iter8/iter8-controller:latest";
-    #echo "Tagging image as latest - $LATEST";
-    #docker tag $IMG $LATEST;
-    #export IMG=$LATEST;
-    #make docker-push;
-  fi
-fi
-
+echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin;
+export IMG="iter8/iter8-controller:$TRAVIS_BRANCH";
+echo "Building PR Docker image - $IMG";
+make docker-build;
+make docker-push;
+#LATEST="iter8/iter8-controller:latest";
+#echo "Tagging image as latest - $LATEST";
+#docker tag $IMG $LATEST;
+#export IMG=$LATEST;
+#make docker-push;


### PR DESCRIPTION
1. Stop spinning up a VM during PR to call build_image.sh only to not do anything in the script
2. Don't do unit test and e2e tests after a PR is merged to save Travis resources