### PR TITLE
making v1 and v2 telemetry scenarios consistent

### DIFF
--- a/doc/tutorials/istio/bookinfo/canary_reviews-v2_to_reviews-v3_telemetry-v2.yaml
+++ b/doc/tutorials/istio/bookinfo/canary_reviews-v2_to_reviews-v3_telemetry-v2.yaml
@@ -11,8 +11,8 @@ spec:
   trafficControl:
     strategy: check_and_increment
     interval: 30s
-    trafficStepSize: 20
-    maxIterations: 8
+    trafficStepSize: 25
+    maxIterations: 4
     maxTrafficPercentage: 80
   analysis:
     analyticsService: "http://iter8-analytics:8080"


### PR DESCRIPTION
Scenarios are somehow not consistent between v1/v2 telemetry on the master branch, but on v0.2 branch, they're consistent.