### PR TITLE
auto detect istio/k8s version to select the correct grafana dashboard

### DIFF
--- a/hack/grafana_install_dashboard.sh
+++ b/hack/grafana_install_dashboard.sh
@@ -2,6 +2,61 @@
 
 #set -x
 
+verlte() {
+  [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+verlt() {
+  [ "$1" = "$2" ] && return 1 || verlte $1 $2
+}
+
+autodetect() {
+
+  ISTIO_VERSION=`kubectl -n istio-system get pods -o yaml | grep "image:" | grep proxy | head -n 1 | awk -F: '{print $3}'`
+  KUBERNETES_VERSION=`kubectl version | grep "Server Version"`
+  KUBERNETES_VERSION_MAJOR=`echo "$KUBERNETES_VERSION" | awk -F\" '{print $2}'`
+  KUBERNETES_VERSION_MINOR=`echo "$KUBERNETES_VERSION" | awk -F\" '{print $4}'`
+  KUBERNETES_VERSION="$KUBERNETES_VERSION_MAJOR.$KUBERNETES_VERSION_MINOR"
+
+  if [ -z "$ISTIO_VERSION" ]; then
+    echo "Cannot detect Istio version, aborting..."
+    return
+  elif [ -z "$KUBERNETES_VERSION" ]; then
+    echo "Cannot detect Kubernetes version, aborting..."
+    return
+  fi
+
+  echo "Istio version: $ISTIO_VERSION"
+  echo "Kubernetes version: $KUBERNETES_VERSION"
+
+  if verlte "$ISTIO_VERSION" "1.5.0"; then
+
+    echo "Using Istio telemetry v1"
+
+    if verlt "$KUBERNETES_VERSION" "1.16"; then
+      echo "Using Prometheus queries for older Kubernetes (<v1.16) "
+      DASHBOARD_DEFN="https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio-telemetry-v1.json"
+    else
+      echo "Using Prometheus queries for newer Kubernetes (>=v1.16)"
+      DASHBOARD_DEFN="https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio-telemetry-v1-k8s-16.json"
+    fi
+
+  else
+    echo "Using Istio telemetry v2"
+
+    if verlt "$KUBERNETES_VERSION" "1.16"; then
+      echo "Using Prometheus queries for older Kubernetes (<v1.16) "
+      DASHBOARD_DEFN="https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio-telemetry-v2.json"
+    else
+      echo "Using Prometheus queries for newer Kubernetes (>=v1.16)"
+      DASHBOARD_DEFN="https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio-telemetry-v2-k8s-16.json"
+    fi
+  fi
+}
+
+# Run auto detection code only if $DASHBOARD_DEFN is not defined
+[ -z $DASHBOARD_DEFN ] && autodetect
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 DASHBOARD_UID=eXPEaNnZz

--- a/hack/grafana_install_dashboard.sh
+++ b/hack/grafana_install_dashboard.sh
@@ -2,6 +2,9 @@
 
 #set -x
 
+# Use default istio namespace unless ISTIO_NAMESPACE is defined
+: "${ISTIO_NAMESPACE:=istio-system}"
+
 verlte() {
   [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
 }
@@ -11,6 +14,8 @@ verlt() {
 }
 
 autodetect() {
+  echo "Istio namespace: $ISTIO_NAMESPACE"
+  MIXER_DISABLED=`kubectl -n $ISTIO_NAMESPACE get cm istio -o json | jq .data.mesh | grep -o 'disableMixerHttpReports: [A-Za-z]\+' | cut -d ' ' -f2`
 
   ISTIO_VERSION=`kubectl -n istio-system get pods -o yaml | grep "image:" | grep proxy | head -n 1 | awk -F: '{print $3}'`
   KUBERNETES_VERSION=`kubectl version | grep "Server Version"`
@@ -20,16 +25,20 @@ autodetect() {
 
   if [ -z "$ISTIO_VERSION" ]; then
     echo "Cannot detect Istio version, aborting..."
-    return
+    exit 1
+  elif [ -z "$MIXER_DISABLED" ]; then
+    echo "Cannot detect if Istio mixer is enabled, aborting..."
+    exit 1
   elif [ -z "$KUBERNETES_VERSION" ]; then
     echo "Cannot detect Kubernetes version, aborting..."
-    return
+    exit 1
   fi
 
   echo "Istio version: $ISTIO_VERSION"
+  echo "Istio mixer disabled: $MIXER_DISABLED"
   echo "Kubernetes version: $KUBERNETES_VERSION"
 
-  if verlt "$ISTIO_VERSION" "1.5"; then
+  if [ "$MIXER_DISABLED" = "false" ]; then
 
     echo "Using Istio telemetry v1"
 
@@ -52,10 +61,13 @@ autodetect() {
       DASHBOARD_DEFN="https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio-telemetry-v2-k8s-16.json"
     fi
   fi
+  echo "Installing Grafana dashboard from $DASHBOARD_DEFN"
 }
 
 # Run auto detection code only if $DASHBOARD_DEFN is not defined
 [ -z $DASHBOARD_DEFN ] && autodetect
+
+exit
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/hack/grafana_install_dashboard.sh
+++ b/hack/grafana_install_dashboard.sh
@@ -17,7 +17,7 @@ autodetect() {
   echo "Istio namespace: $ISTIO_NAMESPACE"
   MIXER_DISABLED=`kubectl -n $ISTIO_NAMESPACE get cm istio -o json | jq .data.mesh | grep -o 'disableMixerHttpReports: [A-Za-z]\+' | cut -d ' ' -f2`
 
-  ISTIO_VERSION=`kubectl -n istio-system get pods -o yaml | grep "image:" | grep proxy | head -n 1 | awk -F: '{print $3}'`
+  ISTIO_VERSION=`kubectl -n  $ISTIO_NAMESPACE get pods -o yaml | grep "image:" | grep proxy | head -n 1 | awk -F: '{print $3}'`
   KUBERNETES_VERSION=`kubectl version | grep "Server Version"`
   KUBERNETES_VERSION_MAJOR=`echo "$KUBERNETES_VERSION" | awk -F\" '{print $2}'`
   KUBERNETES_VERSION_MINOR=`echo "$KUBERNETES_VERSION" | awk -F\" '{print $4}'`

--- a/hack/grafana_install_dashboard.sh
+++ b/hack/grafana_install_dashboard.sh
@@ -29,7 +29,7 @@ autodetect() {
   echo "Istio version: $ISTIO_VERSION"
   echo "Kubernetes version: $KUBERNETES_VERSION"
 
-  if verlte "$ISTIO_VERSION" "1.5.0"; then
+  if verlt "$ISTIO_VERSION" "1.5"; then
 
     echo "Using Istio telemetry v1"
 

--- a/hack/grafana_install_dashboard.sh
+++ b/hack/grafana_install_dashboard.sh
@@ -67,8 +67,6 @@ autodetect() {
 # Run auto detection code only if $DASHBOARD_DEFN is not defined
 [ -z $DASHBOARD_DEFN ] && autodetect
 
-exit
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 DASHBOARD_UID=eXPEaNnZz


### PR DESCRIPTION
Auto-detect Istio and K8s version and automatically select the right Grafana dashboard. The logic to detect v1 vs. v2 telemetry is not yet confirmed.