### PR TITLE
fix destination rule definition

### DIFF
--- a/pkg/controller/experiment/routing/istio.go
+++ b/pkg/controller/experiment/routing/istio.go
@@ -113,7 +113,7 @@ func (b *DestinationRuleBuilder) WithSubset(d *appsv1.Deployment, subsetName str
 	}
 	b.Spec.Subsets[idx] = &networkingv1alpha3.Subset{
 		Name:   subsetName,
-		Labels: d.Spec.Template.Labels,
+		Labels: d.Spec.Template.ObjectMeta.Labels,
 	}
 
 	return b

--- a/pkg/controller/experiment/targets/targets.go
+++ b/pkg/controller/experiment/targets/targets.go
@@ -83,12 +83,12 @@ func (t *Targets) GetCandidates(context context.Context, instance *iter8v1alpha2
 		return fmt.Errorf("Mismatch of candidate list length, %d in targets while %d in instance",
 			len(instance.Spec.Candidates), len(t.Candidates))
 	}
-	for i, candidate := range t.Candidates {
-		candidate = &appsv1.Deployment{}
+	for i := range t.Candidates {
+		t.Candidates[i] = &appsv1.Deployment{}
 		err = t.client.Get(context, types.NamespacedName{
 			Name:      instance.Spec.Candidates[i],
 			Namespace: t.namespace},
-			candidate)
+			t.Candidates[i])
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Destination rules were not being updated with candidate information. This stemmed from 2 key reasons: (a) we were updating copies of array entries but not the arrays themselves and (b) we labeled the rules as progressing before both the candidate and baseline rules were defined.

An unrelated change to the iteration update status message is included in the PR.